### PR TITLE
$query override and chained method calls

### DIFF
--- a/src/Casinelli/Wikipedia/QueryBuilder.php
+++ b/src/Casinelli/Wikipedia/QueryBuilder.php
@@ -88,7 +88,7 @@ class QueryBuilder {
 
 		$this->query["format"] = $format;
 
-		return true;
+		return $this;
 	}
 
 	/**
@@ -110,7 +110,7 @@ class QueryBuilder {
 
 		$this->query["exlimits"] = $value;
 
-		return true;
+		return $this;
 	}
 
 	/**
@@ -133,7 +133,7 @@ class QueryBuilder {
 		$this->query["exchars"] = $chars;
 		$this->query["exsentences"] = null;
 
-		return true;
+		return $this;
 	}
 
 	/**
@@ -156,7 +156,7 @@ class QueryBuilder {
 		$this->query["exsentences"] = $sentences;
 		$this->query["exchars"] = null;
 
-		return true;
+		return $this;
 	}
 
 	/**
@@ -176,7 +176,7 @@ class QueryBuilder {
 	{
 		$this->query["titles"] = $titles;
 
-		return true;
+		return $this;
 	}
 
 	/**
@@ -190,7 +190,7 @@ class QueryBuilder {
 	}
 
 	/**
-	 * Sett the explaintext query value
+	 * Set the explaintext query value
 	 * @param bool $value True for Plain text, false for HTML
 	 */
 	public function setExtractsPlainText($value)
@@ -206,6 +206,6 @@ class QueryBuilder {
 	{
 		$this->query = $query;
 
-		return true;
+		return $this;
 	}
 }

--- a/src/Casinelli/Wikipedia/QueryBuilder.php
+++ b/src/Casinelli/Wikipedia/QueryBuilder.php
@@ -24,7 +24,6 @@ class QueryBuilder {
 		'exlimit'     => 1,			// Max 20
 		'titles'      => null,		// The page title to search
 		'explaintext' => null,	// Return format as plain text instead of HTML
-		
 		'format'      => 'json',		// json|xml|php|wddx|yaml|jsonfm|txt|dbg|dump
 	];
 
@@ -34,6 +33,18 @@ class QueryBuilder {
 	 * @var array
 	 */
 	protected $allowedFormats = ['json', 'xml', 'php', 'wddx', 'yaml', 'jsonfm', 'txt', 'dbg', 'dump'];
+
+    /**
+     * QueryBuilder constructor.
+     *
+     * @param array $query Override all query parameters at once
+     */
+	public function __construct(array $query = [])
+    {
+        if (count($query)) {
+            $this->query = $query;
+        }
+    }
 
 	public function fetch()
 	{

--- a/src/Casinelli/Wikipedia/QueryBuilder.php
+++ b/src/Casinelli/Wikipedia/QueryBuilder.php
@@ -198,4 +198,14 @@ class QueryBuilder {
 		return $this->query["explaintext"] = $value;
 	}
 
+    /**
+	 * Override the entire query array in one go
+	 * @param array $setQuery an array of query parameters
+	 */
+	public function setQuery(array $query = [])
+	{
+		$this->query = $query;
+
+		return true;
+	}
 }


### PR DESCRIPTION
Hey

I've made a couple of changes to the library to fit how I was using it - I figured I'd put in a pull request in case you thought they looked useful.  Feel free to deny the PR if not :-)

First change(s) was to add a method for overriding the entire $query block in one go.  This gives me the ability to add/remove as many parameters as I need to without being limited to what setter methods are available.

This can now be done via the constructor when the class is first instantiated, or by calling:

 `$querybuilder->setQuery(['param1' => 'value1', 'param2' => 'value2']);`

The second was to return $this instead of true in the setters.  This allowed to to make chained calls, ie:

`$wikipedia->setFormat("php")->setTitles("Singapore")->setExtractsPlainText(true)->fetch();`

Like I say, feel free to deny. Either way, thanks for the library, it's been really useful :-)
