### PR TITLE
setApi to retrieve results in other languages etc.

### DIFF
--- a/src/Casinelli/Wikipedia/QueryBuilder.php
+++ b/src/Casinelli/Wikipedia/QueryBuilder.php
@@ -22,6 +22,7 @@ class QueryBuilder {
 		'exchars'     => null,		// No less than 1
 		'exsentences' => null,	// Between 1 and 10
 		'exlimit'     => 1,			// Max 20
+		'redirects'   => 1,			// Follow redirects eg between synonyms
 		'titles'      => null,		// The page title to search
 		'explaintext' => null,	// Return format as plain text instead of HTML
 		'format'      => 'json',		// json|xml|php|wddx|yaml|jsonfm|txt|dbg|dump

--- a/src/Casinelli/Wikipedia/QueryBuilder.php
+++ b/src/Casinelli/Wikipedia/QueryBuilder.php
@@ -34,6 +34,16 @@ class QueryBuilder {
 	 */
 	protected $allowedFormats = ['json', 'xml', 'php', 'wddx', 'yaml', 'jsonfm', 'txt', 'dbg', 'dump'];
 
+	/**
+	 * Change the API url
+	 * @param string $url
+	 */
+	public function setApi($url)
+	{
+		$this->url = $url;
+		return $this;
+	}
+	
     /**
      * QueryBuilder constructor.
      *


### PR DESCRIPTION
Ability to change the url extends the application of the package so also be used to retrieve texts in other languages:
ex. http://**de**.wikipedia.org/w/api.php for results in german or http://**es**.wikipedia.org/w/api.php for spanish

Redirects increases the chance of a result ex. without it a query for "Berlusconi" would return blank, but with redirects it would return the extract for "Silvio Berlusconi".