### PR TITLE
Allow for more recent Laravel versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0"
+        "illuminate/support": ">=5.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hey @Casinelli 

I've allowed newer versions of Laravel. It works for my app with Laravel 8 on PHP 8.

Cheers,
Peter